### PR TITLE
Change "Simple (Mobile Tools)" labels to "Fossify"

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Official Site > [https://grapheneos.org](https://grapheneos.org)
 - Music
   - [InnerTune](https://github.com/z-huang/InnerTune/releases/latest) - A Material 3 YouTube Music client for Android
 - Photo/Video Gallery
-  - [Simple Gallery](https://github.com/FossifyOrg/Gallery/releases/latest) - A premium app for managing and editing your photos, videos, GIFs without ads
+  - [Fossify Gallery](https://github.com/FossifyOrg/Gallery/releases/latest) - A premium app for managing and editing your photos, videos, GIFs without ads
 - Notes
-  - [Simple Notes](https://github.com/FossifyOrg/Notes/releases/latest) - A simple textfield for adding quick notes without ads.
+  - [Fossify Notes](https://github.com/FossifyOrg/Notes/releases/latest) - A simple textfield for adding quick notes without ads.
 - Secure Messaging
   - [Signal](https://signal.org/android/apk/) - A private messenger for Android. 
   - [Session](https://github.com/oxen-io/session-android/releases/latest) - A private messenger for Android.


### PR DESCRIPTION
* Since the modified links already point to Fossify forks, it's just the labels that still reference SMT
* See this [article](https://www.androidauthority.com/simple-mobile-tools-acquisition-3391041/) on what happened to Simple Mobile Tools (got acquired by an ad company?)
* [Fossify](https://github.com/fossifyorg) made forks of SMT's apps from December 2023 and is currently working on getting everything back on track